### PR TITLE
pep8, fix ord()-bug 

### DIFF
--- a/pyxhook.py
+++ b/pyxhook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # pyxhook -- an extension to emulate some of the PyHook library on linux.
 #
@@ -24,73 +24,79 @@
 #
 #    Thanks to the python-xlib team. This wouldn't have been possible without
 #    your code.
-#    
-#    This requires: 
+#
+#    This requires:
 #    at least python-xlib 1.4
 #    xwindows must have the "record" extension present, and active.
-#    
-#    This file has now been somewhat extensively modified by 
+#
+#    This file has now been somewhat extensively modified by
 #    Daniel Folkinshteyn <nanotube@users.sf.net>
 #    So if there are any bugs, they are probably my fault. :)
 
 import sys
-import os
 import re
 import time
 import threading
 
-from Xlib import X, XK, display, error
+from Xlib import X, XK, display
 from Xlib.ext import record
 from Xlib.protocol import rq
 
 #######################################################################
-########################START CLASS DEF################################
+# #######################START CLASS DEF################################
 #######################################################################
 
-class HookManager(threading.Thread):
-    """This is the main class. Instantiate it, and you can hand it KeyDown and KeyUp (functions in your own code) which execute to parse the pyxhookkeyevent class that is returned.
 
-    This simply takes these two values for now:
-    KeyDown = The function to execute when a key is pressed, if it returns anything. It hands the function an argument that is the pyxhookkeyevent class.
-    KeyUp = The function to execute when a key is released, if it returns anything. It hands the function an argument that is the pyxhookkeyevent class.
+class HookManager(threading.Thread):
+
+    """This is the main class.
+
+    Instantiate it, and you can hand it KeyDown and KeyUp (functions in your
+    own code) which execute to parse the pyxhookkeyevent class that is
+    returned. This simply takes these two values for now:
+    KeyDown = The function to execute when a key is pressed, if it returns
+    anything. It hands the function an argument that is the pyxhookkeyevent
+    class.KeyUp = The function to execute when a key is released, if it returns
+    anything. It hands the function an argument that is the pyxhookkeyevent
+    class.
     """
-    
+
     def __init__(self):
         threading.Thread.__init__(self)
         self.finished = threading.Event()
-        
+
         # Give these some initial values
         self.mouse_position_x = 0
         self.mouse_position_y = 0
-        self.ison = {"shift":False, "caps":False}
-        
+        self.ison = {"shift": False, "caps": False}
+
         # Compile our regex statements.
         self.isshift = re.compile('^Shift')
         self.iscaps = re.compile('^Caps_Lock')
-        self.shiftablechar = re.compile('^[a-z0-9]$|^minus$|^equal$|^bracketleft$|^bracketright$|^semicolon$|^backslash$|^apostrophe$|^comma$|^period$|^slash$|^grave$')
+        self.shiftablechar = re.compile('^[a-z0-9]$|^minus$|^equal$|'
+                                        '^bracketleft$|^bracketright$|'
+                                        '^semicolon$|^backslash$|^apostrophe$|'
+                                        '^comma$|^period$|^slash$|^grave$')
         self.logrelease = re.compile('.*')
         self.isspace = re.compile('^space$')
-        
+
         # Assign default function actions (do nothing).
         self.KeyDown = lambda x: True
         self.KeyUp = lambda x: True
         self.MouseAllButtonsDown = lambda x: True
         self.MouseAllButtonsUp = lambda x: True
-        
-        self.contextEventMask = [X.KeyPress,X.MotionNotify]
-        
+
+        self.contextEventMask = [X.KeyPress, X.MotionNotify]
+
         # Hook to our display.
         self.local_dpy = display.Display()
         self.record_dpy = display.Display()
-        
+
     def run(self):
         # Check if the extension is present
         if not self.record_dpy.has_extension("RECORD"):
-            print "RECORD extension not found"
+            print("RECORD extension not found")
             sys.exit(1)
-        r = self.record_dpy.record_get_version(0, 0)
-        print "RECORD extension version %d.%d" % (r.major_version, r.minor_version)
-
         # Create a recording context; we only want key and mouse events
         self.ctx = self.record_dpy.record_create_context(
                 0,
@@ -101,14 +107,16 @@ class HookManager(threading.Thread):
                         'ext_requests': (0, 0, 0, 0),
                         'ext_replies': (0, 0, 0, 0),
                         'delivered_events': (0, 0),
-                        'device_events': tuple(self.contextEventMask), #(X.KeyPress, X.ButtonPress),
+                        # (X.KeyPress, X.ButtonPress),
+                        'device_events': tuple(self.contextEventMask),
                         'errors': (0, 0),
                         'client_started': False,
                         'client_died': False,
                 }])
 
-        # Enable the context; this only returns after a call to record_disable_context,
-        # while calling the callback function in the meantime
+        # Enable the context; this only returns after a call to
+        # record_disable_context, while calling the callback function
+        # in the meantime
         self.record_dpy.record_enable_context(self.ctx, self.processevents)
         # Finally free the context
         self.record_dpy.record_free_context(self.ctx)
@@ -117,37 +125,40 @@ class HookManager(threading.Thread):
         self.finished.set()
         self.local_dpy.record_disable_context(self.ctx)
         self.local_dpy.flush()
-    
+
     def printevent(self, event):
-        print event
-    
+        print(event)
+
     def HookKeyboard(self):
         pass
-        # We don't need to do anything here anymore, since the default mask 
+        # We don't need to do anything here anymore, since the default mask
         # is now set to contain X.KeyPress
-        #self.contextEventMask[0] = X.KeyPress
-    
+        # self.contextEventMask[0] = X.KeyPress
+
     def HookMouse(self):
         pass
-        # We don't need to do anything here anymore, since the default mask 
+        # We don't need to do anything here anymore, since the default mask
         # is now set to contain X.MotionNotify
-        
+
         # need mouse motion to track pointer position, since ButtonPress events
         # don't carry that info.
-        #self.contextEventMask[1] = X.MotionNotify
-    
+        # self.contextEventMask[1] = X.MotionNotify
+
     def processevents(self, reply):
         if reply.category != record.FromServer:
             return
         if reply.client_swapped:
-            print "* received swapped protocol data, cowardly ignored"
+            print("* received swapped protocol data, cowardly ignored")
             return
-        if not len(reply.data) or ord(reply.data[0]) < 2:
+        if not len(reply.data):
             # not an event
             return
         data = reply.data
         while len(data):
-            event, data = rq.EventField(None).parse_binary_value(data, self.record_dpy.display, None, None)
+            event, data = (rq.EventField(None).
+                           parse_binary_value(data,
+                                              self.record_dpy.display,
+                                              None, None))
             if event.type == X.KeyPress:
                 hookevent = self.keypressevent(event)
                 self.KeyDown(hookevent)
@@ -161,38 +172,43 @@ class HookManager(threading.Thread):
                 hookevent = self.buttonreleaseevent(event)
                 self.MouseAllButtonsUp(hookevent)
             elif event.type == X.MotionNotify:
-                # use mouse moves to record mouse position, since press and release events
-                # do not give mouse position info (event.root_x and event.root_y have 
-                # bogus info).
+                # use mouse moves to record mouse position, since press and
+                # release events do not give mouse position
+                # info (event.root_x and event.root_y have bogus info).
                 self.mousemoveevent(event)
-        
-        #print "processing events...", event.type
+
+        # print "processing events...", event.type
 
     def keypressevent(self, event):
-        matchto = self.lookup_keysym(self.local_dpy.keycode_to_keysym(event.detail, 0))
-        if self.shiftablechar.match(self.lookup_keysym(self.local_dpy.keycode_to_keysym(event.detail, 0))): ## This is a character that can be typed.
-            if self.ison["shift"] == False:
+        matchto = self.lookup_keysym(
+            self.local_dpy.keycode_to_keysym(event.detail, 0))
+        # This is a character that can be typed.
+        if self.shiftablechar.match(
+            self.lookup_keysym(
+                self.local_dpy.keycode_to_keysym(event.detail, 0))):
+            if not self.ison["shift"]:
                 keysym = self.local_dpy.keycode_to_keysym(event.detail, 0)
                 return self.makekeyhookevent(keysym, event)
             else:
                 keysym = self.local_dpy.keycode_to_keysym(event.detail, 1)
                 return self.makekeyhookevent(keysym, event)
-        else: ## Not a typable character.
+        else:  # Not a typable character.
             keysym = self.local_dpy.keycode_to_keysym(event.detail, 0)
             if self.isshift.match(matchto):
                 self.ison["shift"] = self.ison["shift"] + 1
             elif self.iscaps.match(matchto):
-                if self.ison["caps"] == False:
+                if not self.ison["caps"]:
                     self.ison["shift"] = self.ison["shift"] + 1
                     self.ison["caps"] = True
-                if self.ison["caps"] == True:
+                if not self.ison["caps"]:
                     self.ison["shift"] = self.ison["shift"] - 1
                     self.ison["caps"] = False
             return self.makekeyhookevent(keysym, event)
-    
+
     def keyreleaseevent(self, event):
-        if self.shiftablechar.match(self.lookup_keysym(self.local_dpy.keycode_to_keysym(event.detail, 0))):
-            if self.ison["shift"] == False:
+        if self.shiftablechar.match(self.lookup_keysym(
+           self.local_dpy.keycode_to_keysym(event.detail, 0))):
+            if not self.ison["shift"]:
                 keysym = self.local_dpy.keycode_to_keysym(event.detail, 0)
             else:
                 keysym = self.local_dpy.keycode_to_keysym(event.detail, 1)
@@ -204,30 +220,36 @@ class HookManager(threading.Thread):
         return self.makekeyhookevent(keysym, event)
 
     def buttonpressevent(self, event):
-        #self.clickx = self.rootx
-        #self.clicky = self.rooty
+        # self.clickx = self.rootx
+        # self.clicky = self.rooty
         return self.makemousehookevent(event)
 
     def buttonreleaseevent(self, event):
-        #if (self.clickx == self.rootx) and (self.clicky == self.rooty):
-            ##print "ButtonClick " + str(event.detail) + " x=" + str(self.rootx) + " y=" + str(self.rooty)
-            #if (event.detail == 1) or (event.detail == 2) or (event.detail == 3):
-                #self.captureclick()
-        #else:
-            #pass
-        
+        # if (self.clickx == self.rootx) and (self.clicky == self.rooty):
+            # print("ButtonClick " + str(event.detail) + " x=" +
+            #       str(self.rootx) + " y=" + str(self.rooty))
+            # if (event.detail == 1) or (event.detail == 2) or
+            #    (event.detail == 3):
+                # self.captureclick()
+        # else:
+            # pass
+
         return self.makemousehookevent(event)
-        
-        #    sys.stdout.write("ButtonDown " + str(event.detail) + " x=" + str(self.clickx) + " y=" + str(self.clicky) + "\n")
-        #    sys.stdout.write("ButtonUp " + str(event.detail) + " x=" + str(self.rootx) + " y=" + str(self.rooty) + "\n")
-        #sys.stdout.flush()
+
+        #    sys.stdout.write("ButtonDown " + str(event.detail) +
+        #                     " x=" + str(self.clickx) + " y=" +
+        #                     str(self.clicky) + "\n")
+        #    sys.stdout.write("ButtonUp " + str(event.detail) + " x=" +
+        #                      str(self.rootx) + " y=" + str(self.rooty) +
+        #                      "\n")
+        # sys.stdout.flush()
 
     def mousemoveevent(self, event):
         self.mouse_position_x = event.root_x
         self.mouse_position_y = event.root_y
 
-    # need the following because XK.keysym_to_string() only does printable chars
-    # rather than being the correct inverse of XK.string_to_keysym()
+    # need the following because XK.keysym_to_string() only does printable
+    # chars rather than being the correct inverse of XK.string_to_keysym()
     def lookup_keysym(self, keysym):
         for name in dir(XK):
             if name.startswith("XK_") and getattr(XK, name) == keysym:
@@ -240,15 +262,18 @@ class HookManager(threading.Thread):
             return asciinum
         else:
             return 0
-    
+
     def makekeyhookevent(self, keysym, event):
         storewm = self.xwindowinfo()
         if event.type == X.KeyPress:
             MessageName = "key down"
         elif event.type == X.KeyRelease:
             MessageName = "key up"
-        return pyxhookkeyevent(storewm["handle"], storewm["name"], storewm["class"], self.lookup_keysym(keysym), self.asciivalue(keysym), False, event.detail, MessageName)
-    
+        return pyxhookkeyevent(storewm["handle"], storewm["name"],
+                               storewm["class"], self.lookup_keysym(keysym),
+                               self.asciivalue(keysym), False, event.detail,
+                               MessageName)
+
     def makemousehookevent(self, event):
         storewm = self.xwindowinfo()
         if event.detail == 1:
@@ -268,8 +293,10 @@ class HookManager(threading.Thread):
             MessageName = MessageName + "down"
         elif event.type == X.ButtonRelease:
             MessageName = MessageName + "up"
-        return pyxhookmouseevent(storewm["handle"], storewm["name"], storewm["class"], (self.mouse_position_x, self.mouse_position_y), MessageName)
-    
+        return pyxhookmouseevent(storewm["handle"], storewm["name"],
+                                 storewm["class"], (self.mouse_position_x,
+                                 self.mouse_position_y), MessageName)
+
     def xwindowinfo(self):
         try:
             windowvar = self.local_dpy.get_input_focus().focus
@@ -277,37 +304,44 @@ class HookManager(threading.Thread):
             wmclass = windowvar.get_wm_class()
             wmhandle = str(windowvar)[20:30]
         except:
-            ## This is to keep things running smoothly. It almost never happens, but still...
-            return {"name":None, "class":None, "handle":None}
-        if (wmname == None) and (wmclass == None):
+            # This is to keep things running smoothly.
+            # It almost never happens, but still...
+            return {"name": None, "class": None, "handle": None}
+        if (wmname is None) and (wmclass is None):
             try:
                 windowvar = windowvar.query_tree().parent
                 wmname = windowvar.get_wm_name()
                 wmclass = windowvar.get_wm_class()
                 wmhandle = str(windowvar)[20:30]
             except:
-                ## This is to keep things running smoothly. It almost never happens, but still...
-                return {"name":None, "class":None, "handle":None}
-        if wmclass == None:
-            return {"name":wmname, "class":wmclass, "handle":wmhandle}
+                # This is to keep things running smoothly
+                # It almost never happens, but still...
+                return {"name": None, "class": None, "handle": None}
+        if wmclass is None:
+            return {"name": wmname, "class": wmclass, "handle": wmhandle}
         else:
-            return {"name":wmname, "class":wmclass[0], "handle":wmhandle}
+            return {"name": wmname, "class": wmclass[0], "handle": wmhandle}
+
 
 class pyxhookkeyevent:
+
     """This is the class that is returned with each key event.f
     It simply creates the variables below in the class.
-    
+
     Window = The handle of the window.
     WindowName = The name of the window.
     WindowProcName = The backend process for the window.
     Key = The key pressed, shifted to the correct caps value.
-    Ascii = An ascii representation of the key. It returns 0 if the ascii value is not between 31 and 256.
-    KeyID = This is just False for now. Under windows, it is the Virtual Key Code, but that's a windows-only thing.
-    ScanCode = Please don't use this. It differs for pretty much every type of keyboard. X11 abstracts this information anyway.
+    Ascii = An ascii representation of the key. It returns 0 if the ascii value
+    is not between 31 and 256. KeyID = This is just False for now.
+    Under windows, it is the Virtual Key Code, but that's a windows-only thing.
+    ScanCode = Please don't use this. It differs for pretty much every type of
+    keyboard. X11 abstracts this information anyway.
     MessageName = "key down", "key up".
     """
-    
-    def __init__(self, Window, WindowName, WindowProcName, Key, Ascii, KeyID, ScanCode, MessageName):
+
+    def __init__(self, Window, WindowName, WindowProcName, Key, Ascii, KeyID,
+                 ScanCode, MessageName):
         self.Window = Window
         self.WindowName = WindowName
         self.WindowProcName = WindowProcName
@@ -316,35 +350,48 @@ class pyxhookkeyevent:
         self.KeyID = KeyID
         self.ScanCode = ScanCode
         self.MessageName = MessageName
-    
+
     def __str__(self):
-        return "Window Handle: " + str(self.Window) + "\nWindow Name: " + str(self.WindowName) + "\nWindow's Process Name: " + str(self.WindowProcName) + "\nKey Pressed: " + str(self.Key) + "\nAscii Value: " + str(self.Ascii) + "\nKeyID: " + str(self.KeyID) + "\nScanCode: " + str(self.ScanCode) + "\nMessageName: " + str(self.MessageName) + "\n"
+        return ("Window Handle: " + str(self.Window) + "\nWindow Name: " +
+                str(self.WindowName) + "\nWindow's Process Name: " +
+                str(self.WindowProcName) + "\nKey Pressed: " + str(self.Key) +
+                "\nAscii Value: " + str(self.Ascii) + "\nKeyID: " +
+                str(self.KeyID) + "\nScanCode: " + str(self.ScanCode) +
+                "\nMessageName: " + str(self.MessageName) + "\n")
+
 
 class pyxhookmouseevent:
+
     """This is the class that is returned with each key event.f
     It simply creates the variables below in the class.
-    
+
     Window = The handle of the window.
     WindowName = The name of the window.
     WindowProcName = The backend process for the window.
     Position = 2-tuple (x,y) coordinates of the mouse click
     MessageName = "mouse left|right|middle down", "mouse left|right|middle up".
     """
-    
-    def __init__(self, Window, WindowName, WindowProcName, Position, MessageName):
+
+    def __init__(self, Window, WindowName, WindowProcName, Position,
+                 MessageName):
         self.Window = Window
         self.WindowName = WindowName
         self.WindowProcName = WindowProcName
         self.Position = Position
         self.MessageName = MessageName
-    
+
     def __str__(self):
-        return "Window Handle: " + str(self.Window) + "\nWindow Name: " + str(self.WindowName) + "\nWindow's Process Name: " + str(self.WindowProcName) + "\nPosition: " + str(self.Position) + "\nMessageName: " + str(self.MessageName) + "\n"
+        return ("Window Handle: " + str(self.Window) + "\nWindow Name: " +
+                str(self.WindowName) + "\nWindow's Process Name: " +
+                str(self.WindowProcName) + "\nPosition: " +
+                str(self.Position) + "\nMessageName: " +
+                str(self.MessageName) + "\n")
+
 
 #######################################################################
-#########################END CLASS DEF#################################
+# ########################END CLASS DEF#################################
 #######################################################################
-    
+
 if __name__ == '__main__':
     hm = HookManager()
     hm.HookKeyboard()

--- a/pyxhook.py
+++ b/pyxhook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 #
 # pyxhook -- an extension to emulate some of the PyHook library on linux.
 #
@@ -43,7 +43,7 @@ from Xlib.ext import record
 from Xlib.protocol import rq
 
 #######################################################################
-# #######################START CLASS DEF################################
+########################START CLASS DEF################################
 #######################################################################
 
 
@@ -150,15 +150,13 @@ class HookManager(threading.Thread):
         if reply.client_swapped:
             print("* received swapped protocol data, cowardly ignored")
             return
-        if not len(reply.data):
+        if not len(reply.data) or ord(reply.data[0:1]) < 2:
             # not an event
             return
         data = reply.data
         while len(data):
-            event, data = (rq.EventField(None).
-                           parse_binary_value(data,
-                                              self.record_dpy.display,
-                                              None, None))
+            event, data = rq.EventField(None).parse_binary_value(
+                data, self.record_dpy.display, None, None)
             if event.type == X.KeyPress:
                 hookevent = self.keypressevent(event)
                 self.KeyDown(hookevent)
@@ -200,7 +198,7 @@ class HookManager(threading.Thread):
                 if not self.ison["caps"]:
                     self.ison["shift"] = self.ison["shift"] + 1
                     self.ison["caps"] = True
-                if not self.ison["caps"]:
+                if self.ison["caps"]:
                     self.ison["shift"] = self.ison["shift"] - 1
                     self.ison["caps"] = False
             return self.makekeyhookevent(keysym, event)
@@ -389,7 +387,7 @@ class pyxhookmouseevent:
 
 
 #######################################################################
-# ########################END CLASS DEF#################################
+#########################END CLASS DEF#################################
 #######################################################################
 
 if __name__ == '__main__':


### PR DESCRIPTION
There was still a problem for compatibility in python3.
There was an error: TypeError: ord() expected string of length 1, but int found
The problem was the line 145:
if not len(reply.data) or ord(reply.data[0]) < 2:

In python3 indexing a 'bytes'-object returns an 'int'. ord() is than needless. 
Solution: Indexing from 0 to 1. This will be a 'bytes'- object in python2/3 and makes ord() valid. 
For more information:
https://docs.python.org/3.2/library/stdtypes.html#sequence-types-str-bytes-bytearray-list-tuple-range

My total changes are now:
- pep8
- remove  print "RECORD extension version %d.%d" % (r.major_version, r.minor_version)
- fix ord()-bug

All these changes work for both python2 and for python3. 
