### PR TITLE
Python 2/3 Compatibility

### DIFF
--- a/pyxhook.py
+++ b/pyxhook.py
@@ -142,7 +142,7 @@ class HookManager(threading.Thread):
         if reply.client_swapped:
             print("* received swapped protocol data, cowardly ignored")
             return
-        if not len(reply.data) or ord(reply.data[0]) < 2:
+        if not len(reply.data) or ord(str(reply.data[0])) < 2:
             # not an event
             return
         data = reply.data


### PR DESCRIPTION
Fix `TypeError: ord() expected string of length 1, but int found` error found by running the code on Python 3.4, Linux Mint 17.1.
Works both on Python2 and Python3