### PR TITLE
Fixed the return value for 'asciinum' function

### DIFF
--- a/pyxhook.py
+++ b/pyxhook.py
@@ -238,10 +238,7 @@ class HookManager(threading.Thread):
 
     def asciivalue(self, keysym):
         asciinum = XK.string_to_keysym(self.lookup_keysym(keysym))
-        if asciinum < 256:
-            return asciinum
-        else:
-            return 0
+        return asciinum % 256
     
     def makekeyhookevent(self, keysym, event):
         storewm = self.xwindowinfo()


### PR DESCRIPTION
The 'asciinum' fucntion 'HookManager' class returns a '0' value for special characters like 'Enter' and 'Backspace'. On checking I realized these characters have values as '65293' and '65288' in the ascii field of the event. If you perform a %256 on these numbers, you get the character's ASCII value. All the values less than 256 are taken care of by the modulo operation. And thus I've directly returned the modulo value.