### PR TITLE
Fixes issue #27, all ascii values are now correct

### DIFF
--- a/pyxhook.py
+++ b/pyxhook.py
@@ -90,6 +90,7 @@ class HookManager(threading.Thread):
         )))
         self.logrelease = re.compile('.*')
         self.isspace = re.compile('^space$')
+        self.lookuptable = self.create_lookup_dict()
         # Choose which type of function use
         self.parameters=parameters
         if parameters:
@@ -114,6 +115,11 @@ class HookManager(threading.Thread):
         # Hook to our display.
         self.local_dpy = display.Display()
         self.record_dpy = display.Display()
+
+    def create_lookup_dict(self):
+        return {getattr(XK, name): name[3:] \
+            for name in dir(XK) \
+            if name.startswith("XK_")}
 
     def run(self):
         # Check if the extension is present
@@ -303,10 +309,9 @@ class HookManager(threading.Thread):
     # need the following because XK.keysym_to_string() only does printable
     # chars rather than being the correct inverse of XK.string_to_keysym()
     def lookup_keysym(self, keysym):
-        for name in dir(XK):
-            if name.startswith("XK_") and getattr(XK, name) == keysym:
-                return name[3:]
-        return "[{}]".format(keysym)
+        return self.lookuptable[keysym] \
+            if keysym in self.lookuptable \
+            else "[{}]".format(keysym)
 
     def asciivalue(self, keysym):
         number = XK.string_to_keysym(self.lookup_keysym(keysym))

--- a/pyxhook.py
+++ b/pyxhook.py
@@ -102,7 +102,7 @@ class HookManager(threading.Thread):
         self.MouseAllButtonsDown = self.lambda_function
         self.MouseAllButtonsUp = self.lambda_function
         self.MouseMovement = self.lambda_function
-        
+
         self.KeyDownParameters = {}
         self.KeyUpParameters = {}
         self.MouseAllButtonsDownParameters = {}
@@ -175,7 +175,7 @@ class HookManager(threading.Thread):
 
     def processhookevents(self,action_type,action_parameters,events):
         # In order to avoid duplicate code, i wrote a function that takes the
-        # input value of the action function and, depending on the initialization, 
+        # input value of the action function and, depending on the initialization,
         # launches it or only with the event or passes the parameter
         if self.parameters:
             action_type(events,action_parameters)
@@ -305,12 +305,12 @@ class HookManager(threading.Thread):
     def lookup_keysym(self, keysym):
         for name in dir(XK):
             if name.startswith("XK_") and getattr(XK, name) == keysym:
-                return name.lstrip("XK_")
+                return name[3:]
         return "[{}]".format(keysym)
 
     def asciivalue(self, keysym):
-        asciinum = XK.string_to_keysym(self.lookup_keysym(keysym))
-        return asciinum % 256
+        number = XK.string_to_keysym(self.lookup_keysym(keysym))
+        return number if number < 256 else 0
 
     def makekeyhookevent(self, keysym, event):
         storewm = self.xwindowinfo()


### PR DESCRIPTION
Fixes #27 

Changed lstrip to list indexing, lstrip removes all specified characters not just the first 3.
Changed using modulo to get the ascii table from XK to return 0 for keys outside the ascii range.
Removed some spurious white spaces.
